### PR TITLE
Add missing function - add_section()

### DIFF
--- a/MaxiNet/tools.py
+++ b/MaxiNet/tools.py
@@ -137,6 +137,10 @@ class MaxiNetConfig(RawConfigParser):
         return RawConfigParser.has_section(self, section)
 
     @Pyro4.expose
+    def add_section(self, section):
+        return RawConfigParser.add_section(self, section)
+
+    @Pyro4.expose
     def has_option(self, section, option):
         return RawConfigParser.has_option(self, section, option)
 


### PR DESCRIPTION
In WorkerServer.server.py, if the host section doesn't exist, the code
tries to add it. But the method doesn't exist .. now it does.