### PR TITLE
Add missing method - set()

### DIFF
--- a/MaxiNet/tools.py
+++ b/MaxiNet/tools.py
@@ -133,6 +133,10 @@ class MaxiNetConfig(RawConfigParser):
         return RawConfigParser.get(self, section, option)
 
     @Pyro4.expose
+    def set(self, section, option, val):
+        return RawConfigParser.set(self, section, option, val)
+
+    @Pyro4.expose
     def has_section(self, section):
         return RawConfigParser.has_section(self, section)
 


### PR DESCRIPTION
set() is called in WorkerServer.server.py when the hostname
doesn't exist in configuration file.