### PR TITLE
Containernet 2.0 support

### DIFF
--- a/MaxiNet/Frontend/examples/libvirtNodeWrapper.py
+++ b/MaxiNet/Frontend/examples/libvirtNodeWrapper.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python2
+""" An example showing all available methods and attributes of the NodeWrapper for Docker hosts.
+"""
+
+from MaxiNet.Frontend import maxinet
+from MaxiNet.Frontend.libvirt import LibvirtHost
+from mininet.topo import Topo
+from mininet.node import OVSSwitch
+
+topo = Topo()
+vm1 = topo.addHost("vm1", cls=LibvirtHost, ip="10.0.0.251", disk_image="/srv/images/ubuntu16.04.qcow2")
+
+cluster = maxinet.Cluster()
+exp = maxinet.Experiment(cluster, topo, switch=OVSSwitch)
+exp.setup()
+
+try:
+    node_wrapper = exp.get_node("vm1")
+
+    print("Testing methods:")
+    print("=================")
+    print("updateCpuLimit():")
+    print("\t" + str(node_wrapper.updateCpuLimit(10000, 10000, 1, {0: "1", 1: "0"})))  # cpu_quota, cpu_period, cpu_shares, cores
+
+    print("updateMemoryLimit():")
+    print("\t" + str(node_wrapper.updateMemoryLimit(500)))
+
+    print("")
+    print("Testing attributes:")
+    print("====================")
+    print("dimage = " + str(node_wrapper.disk_image))
+    print("resources = " + str(node_wrapper.resources))
+
+finally:
+    exp.stop()

--- a/MaxiNet/Frontend/libvirt.py
+++ b/MaxiNet/Frontend/libvirt.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python2
+"""LibvirtHost support.
+
+This file wraps the import of the LibvirtHost class from containernet.
+"""
+
+try:
+    from mininet.node import LibvirtHost
+except ImportError as e:
+    Libvirt = None
+    raise ImportError("Failed to import LibvirtHost. Make sure ContainerNet2.0 is installed properly.")

--- a/MaxiNet/Frontend/maxinet.py
+++ b/MaxiNet/Frontend/maxinet.py
@@ -1612,6 +1612,10 @@ class NodeWrapper(object):
         """Checks if the node wrapper belongs to a docker host."""
         return self._get("__class__").__name__ == "Docker"
 
+    def is_libvirt(self):
+        """Checks if the node wrapper belongs to a docker host."""
+        return self._get("__class__").__name__ == "LibvirtHost"
+
     def _call(self, cmd, *params1, **params2):
         """Send method call to remote mininet instance and get return.
 
@@ -1667,6 +1671,11 @@ class NodeWrapper(object):
                         "cgroupGet", "update_resources"]:
                 return method
             elif name in ["dimage", "resources", "volumes"]:
+                return self._get(name)
+        elif self.is_libvirt():
+            if name in ["updateCpuLimit", "updateMemoryLimit", "update_resources"]:
+                return method
+            elif name in ["disk_image", "resources"]:
                 return self._get(name)
         else:
             raise AttributeError(name)

--- a/MaxiNet/Frontend/maxinet.py
+++ b/MaxiNet/Frontend/maxinet.py
@@ -1613,7 +1613,7 @@ class NodeWrapper(object):
         return self._get("__class__").__name__ == "Docker"
 
     def is_libvirt(self):
-        """Checks if the node wrapper belongs to a docker host."""
+        """Checks if the node wrapper belongs to a LibvirtHost."""
         return self._get("__class__").__name__ == "LibvirtHost"
 
     def _call(self, cmd, *params1, **params2):

--- a/MaxiNet/WorkerServer/server.py
+++ b/MaxiNet/WorkerServer/server.py
@@ -12,7 +12,7 @@ import time
 
 from mininet.node import UserSwitch, OVSSwitch
 from mininet.link import Link, TCIntf
-from mininet.net import Mininet
+
 import mininet.term
 import Pyro4
 import threading
@@ -21,7 +21,10 @@ import traceback
 from MaxiNet.tools import Tools, MaxiNetConfig
 from MaxiNet.WorkerServer.ssh_manager import SSH_Manager
 
-
+try:
+    from mininet.net import Containernet as Mininet
+except:
+    from mininet.net import Mininet
 
 class WorkerServer(object):
     """Manages the Worker

--- a/MaxiNet/WorkerServer/server.py
+++ b/MaxiNet/WorkerServer/server.py
@@ -23,7 +23,7 @@ from MaxiNet.WorkerServer.ssh_manager import SSH_Manager
 
 try:
     from mininet.net import Containernet as Mininet
-except:
+except ImportError:
     from mininet.net import Mininet
 
 class WorkerServer(object):


### PR DESCRIPTION
I'm developing Libvirt support for containernet under the name containernet 2.0.

For it to work I need some changes as well as the addition of a wrapper class for libvirthosts.

The main change is that instead of importing Mininet, MaxiNet will try to import Containernet and only if it fails it will fall back to Mininet