### PR TITLE
Enable retrieval of "dpid" attribute from switch

### DIFF
--- a/MaxiNet/Frontend/maxinet.py
+++ b/MaxiNet/Frontend/maxinet.py
@@ -1662,7 +1662,7 @@ class NodeWrapper(object):
             "stop", "terminate", "waitOutput", "waitReadable", "write"
         ]:
             return method
-        elif name in ["inNamespace", "name", "params", "waiting"]:
+        elif name in ["dpid", "inNamespace", "name", "params", "waiting"]:
             return self._get(name)
 
         # Containernet specific


### PR DESCRIPTION
It's useful to be able to verify the current dpid of a switch, and is possible in Mininet. A simple change makes the attribute accessible in MaxiNet also: adding "dpid" to the list of attributes for which __getattr__ will attempt to return a value.